### PR TITLE
feat: implement castle defense gameplay systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "little-keyrangers",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "little-keyrangers",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.1.0",
+      "license": "GPL-2.0",
       "dependencies": {
         "phaser": "^3.90.0"
       },

--- a/src/config/stageConfig.ts
+++ b/src/config/stageConfig.ts
@@ -1,0 +1,41 @@
+import { EnemyPath } from '../entities/Enemy';
+
+export interface SpawnConfig {
+  total: number;
+  interval: number;
+  maxConcurrent: number;
+  speed: { min: number; max: number };
+  paths: EnemyPath[];
+}
+
+export interface BombSettings {
+  initial: number;
+  max: number;
+  cooldown: number;
+  comboThreshold: number;
+}
+
+export interface StageConfig {
+  wall: { maxHp: number };
+  dangerZone: number;
+  spawn: SpawnConfig;
+  bombs: BombSettings;
+}
+
+export const defaultStage: StageConfig = {
+  wall: { maxHp: 3 },
+  dangerZone: 140,
+  spawn: {
+    total: 18,
+    interval: 1500,
+    maxConcurrent: 4,
+    speed: { min: 80, max: 140 },
+    paths: ['straight', 'zigzag', 'drift'],
+  },
+  bombs: {
+    initial: 1,
+    max: 2,
+    cooldown: 20000,
+    comboThreshold: 6,
+  },
+};

--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -4,7 +4,23 @@ export interface ScoreSummary {
   score: number;
   combo: number;
   accuracy: number;
-  wordsCompleted: number;
+  enemiesDefeated: number;
+  typedEliminations: number;
+  bombEliminations: number;
+  bombsUsed: number;
+  breaches: number;
+}
+
+export interface BombStatus {
+  charges: number;
+  maxCharges: number;
+  cooldownRemaining: number;
+  cooldown: number;
+}
+
+export interface WallStatus {
+  current: number;
+  max: number;
 }
 
 export const EventBus = new Phaser.Events.EventEmitter();
@@ -14,4 +30,7 @@ export const Events = {
   WordChanged: 'word:changed',
   RoundCompleted: 'round:completed',
   DisplayMessage: 'ui:message',
+  BombStatusUpdated: 'bomb:status',
+  BombActivated: 'bomb:activated',
+  WallStatusUpdated: 'wall:status',
 } as const;

--- a/src/core/UIScene.ts
+++ b/src/core/UIScene.ts
@@ -1,10 +1,13 @@
 import Phaser from 'phaser';
-import { EventBus, Events, ScoreSummary } from './EventBus';
+import { BombStatus, EventBus, Events, ScoreSummary, WallStatus } from './EventBus';
 
 export class UIScene extends Phaser.Scene {
   private scoreText!: Phaser.GameObjects.Text;
   private comboText!: Phaser.GameObjects.Text;
   private accuracyText!: Phaser.GameObjects.Text;
+  private enemyText!: Phaser.GameObjects.Text;
+  private bombText!: Phaser.GameObjects.Text;
+  private wallText!: Phaser.GameObjects.Text;
   private messageText!: Phaser.GameObjects.Text;
   private messageTimer?: Phaser.Time.TimerEvent;
 
@@ -17,10 +20,16 @@ export class UIScene extends Phaser.Scene {
 
     EventBus.on(Events.ScoreUpdated, this.handleScoreUpdated, this);
     EventBus.on(Events.DisplayMessage, this.showMessage, this);
+    EventBus.on(Events.BombStatusUpdated, this.updateBombStatus, this);
+    EventBus.on(Events.WallStatusUpdated, this.updateWallStatus, this);
+    EventBus.on(Events.BombActivated, this.handleBombActivated, this);
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       EventBus.off(Events.ScoreUpdated, this.handleScoreUpdated, this);
       EventBus.off(Events.DisplayMessage, this.showMessage, this);
+      EventBus.off(Events.BombStatusUpdated, this.updateBombStatus, this);
+      EventBus.off(Events.WallStatusUpdated, this.updateWallStatus, this);
+      EventBus.off(Events.BombActivated, this.handleBombActivated, this);
     });
   }
 
@@ -34,6 +43,9 @@ export class UIScene extends Phaser.Scene {
     this.scoreText = this.add.text(16, 16, 'Score: 0', style);
     this.comboText = this.add.text(16, 44, 'Combo: 0', style);
     this.accuracyText = this.add.text(16, 72, 'Accuracy: 100%', style);
+    this.enemyText = this.add.text(16, 100, 'Enemies: 0', style);
+    this.bombText = this.add.text(16, 128, 'Bombs: 0', style);
+    this.wallText = this.add.text(16, 156, 'Wall Integrity: 0/0', style);
 
     this.messageText = this.add
       .text(this.scale.width / 2, this.scale.height - 40, '', {
@@ -51,6 +63,9 @@ export class UIScene extends Phaser.Scene {
       ? Math.round(summary.accuracy * 100)
       : 100;
     this.accuracyText.setText(`Accuracy: ${accuracy}%`);
+    this.enemyText.setText(
+      `Enemies: ${summary.enemiesDefeated} (Typed ${summary.typedEliminations} / Bomb ${summary.bombEliminations})`,
+    );
   }
 
   private showMessage(message: string): void {
@@ -59,5 +74,29 @@ export class UIScene extends Phaser.Scene {
     this.messageTimer = this.time.delayedCall(2500, () => {
       this.messageText.setText('');
     });
+  }
+
+  private updateBombStatus(status: BombStatus): void {
+    if (status.cooldownRemaining > 0 && status.charges === 0) {
+      const seconds = Math.ceil(status.cooldownRemaining / 1000);
+      this.bombText.setText(`Bombs: recharging (${seconds}s)`);
+    } else {
+      this.bombText.setText(`Bombs: ${status.charges}/${status.maxCharges}`);
+    }
+  }
+
+  private updateWallStatus(status: WallStatus): void {
+    this.wallText.setText(`Wall Integrity: ${status.current}/${status.max}`);
+    if (status.current / status.max <= 0.34) {
+      this.wallText.setColor('#f87171');
+    } else if (status.current / status.max <= 0.67) {
+      this.wallText.setColor('#facc15');
+    } else {
+      this.wallText.setColor('#f8fafc');
+    }
+  }
+
+  private handleBombActivated(): void {
+    this.showMessage('炸弹爆裂，敌人被清除！');
   }
 }

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,0 +1,198 @@
+import Phaser from 'phaser';
+
+export type EnemyPath = 'straight' | 'zigzag' | 'drift';
+
+export type EnemyEliminationCause = 'arrow' | 'bomb';
+
+interface EnemyOptions {
+  word: string;
+  path: EnemyPath;
+  speed: number;
+  breachY: number;
+  dangerZone: number;
+}
+
+type EnemyState = 'spawning' | 'descending' | 'eliminating' | 'breached' | 'inactive';
+
+export class Enemy extends Phaser.GameObjects.Container {
+  readonly word: string;
+  readonly path: EnemyPath;
+
+  private readonly body: Phaser.GameObjects.Rectangle;
+  private readonly progressBar: Phaser.GameObjects.Rectangle;
+  private readonly label: Phaser.GameObjects.Text;
+
+  private readonly speed: number;
+  private readonly breachY: number;
+  private readonly dangerZone: number;
+
+  private state: EnemyState = 'spawning';
+  private elapsed = 0;
+  private progress = 0;
+  private readonly startX: number;
+  private readonly zigzagFrequency: number;
+  private readonly driftSpeed: number;
+  private targetted = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, options: EnemyOptions) {
+    super(scene, x, y);
+
+    this.word = options.word;
+    this.path = options.path;
+    this.speed = options.speed;
+    this.breachY = options.breachY;
+    this.dangerZone = options.dangerZone;
+
+    this.startX = x;
+    this.zigzagFrequency = Phaser.Math.FloatBetween(0.0035, 0.0055);
+    this.driftSpeed = Phaser.Math.FloatBetween(-12, 12);
+
+    const width = Math.max(120, this.word.length * 28);
+    const height = 48;
+
+    this.body = scene.add
+      .rectangle(0, 0, width, height, 0x1e293b, 0.92)
+      .setStrokeStyle(2, 0x94a3b8)
+      .setOrigin(0.5);
+
+    this.progressBar = scene.add
+      .rectangle(-width / 2, 0, 0, height, 0x38bdf8, 0.4)
+      .setOrigin(0, 0.5);
+
+    this.label = scene.add
+      .text(0, 0, this.word, {
+        fontFamily: 'monospace',
+        fontSize: '28px',
+        color: '#f8fafc',
+      })
+      .setOrigin(0.5);
+
+    this.add([this.body, this.progressBar, this.label]);
+    scene.add.existing(this);
+
+    this.state = 'descending';
+  }
+
+  advance(delta: number): void {
+    if (this.state !== 'descending') {
+      return;
+    }
+
+    const deltaSeconds = delta / 1000;
+    this.elapsed += delta;
+
+    this.y += this.speed * deltaSeconds;
+
+    if (this.path === 'zigzag') {
+      const amplitude = Math.min(180, Math.max(60, this.word.length * 12));
+      const offset = Math.sin(this.elapsed * this.zigzagFrequency) * amplitude;
+      this.x = Phaser.Math.Clamp(this.startX + offset, 120, this.scene.scale.width - 120);
+    } else if (this.path === 'drift') {
+      this.x = Phaser.Math.Clamp(
+        this.x + this.driftSpeed * deltaSeconds,
+        100,
+        this.scene.scale.width - 100,
+      );
+    }
+
+    if (this.y >= this.breachY) {
+      this.state = 'breached';
+      this.emit('breached');
+      this.fadeOut(180, '#ef4444');
+      return;
+    }
+
+    const distanceToBreach = this.breachY - this.y;
+    if (distanceToBreach <= this.dangerZone) {
+      this.body.setStrokeStyle(3, 0xf97316);
+    } else if (!this.targetted) {
+      this.body.setStrokeStyle(2, 0x94a3b8);
+    }
+  }
+
+  setProgress(progressCount: number): void {
+    this.progress = Phaser.Math.Clamp(progressCount, 0, this.word.length);
+    const ratio = this.word.length === 0 ? 0 : this.progress / this.word.length;
+    const width = this.body.width * ratio;
+    this.progressBar.setDisplaySize(width, this.body.height);
+    this.progressBar.setVisible(ratio > 0);
+
+    if (this.progress >= this.word.length) {
+      this.body.setFillStyle(0x22c55e, 0.9);
+    } else {
+      this.body.setFillStyle(0x1e293b, 0.92);
+    }
+  }
+
+  markAsTargeted(isTarget: boolean): void {
+    this.targetted = isTarget;
+    if (isTarget) {
+      this.body.setStrokeStyle(3, 0x38bdf8);
+    } else if (this.state === 'descending') {
+      this.body.setStrokeStyle(2, 0x94a3b8);
+    }
+  }
+
+  hitByArrow(): void {
+    if (this.state !== 'descending') {
+      return;
+    }
+    this.state = 'eliminating';
+    this.scene.sound?.play?.('arrow-hit');
+    this.scene.tweens.add({
+      targets: this,
+      y: this.y + 200,
+      alpha: 0,
+      duration: 320,
+      ease: Phaser.Math.Easing.Quadratic.In,
+      onComplete: () => {
+        this.state = 'inactive';
+        this.emit('eliminated', { cause: 'arrow' as EnemyEliminationCause });
+        this.destroy();
+      },
+    });
+  }
+
+  eliminateByBomb(): void {
+    if (this.state !== 'descending') {
+      return;
+    }
+    this.state = 'eliminating';
+    this.scene.tweens.add({
+      targets: this,
+      angle: 360,
+      scale: 0.2,
+      alpha: 0,
+      duration: 260,
+      ease: Phaser.Math.Easing.Back.In,
+      onComplete: () => {
+        this.state = 'inactive';
+        this.emit('eliminated', { cause: 'bomb' as EnemyEliminationCause });
+        this.destroy();
+      },
+    });
+  }
+
+  private fadeOut(offset: number, color: string): void {
+    this.body.setStrokeStyle(3, Phaser.Display.Color.HexStringToColor(color).color);
+    this.scene.tweens.add({
+      targets: this,
+      alpha: 0,
+      y: this.y + offset,
+      duration: 280,
+      ease: Phaser.Math.Easing.Cubic.In,
+      onComplete: () => {
+        this.state = 'inactive';
+        this.emit('breach:completed');
+        this.destroy();
+      },
+    });
+  }
+
+  override destroy(fromScene?: boolean): void {
+    this.body.destroy();
+    this.progressBar.destroy();
+    this.label.destroy();
+    super.destroy(fromScene);
+  }
+}

--- a/src/entities/PlayerStats.ts
+++ b/src/entities/PlayerStats.ts
@@ -1,0 +1,26 @@
+export class PlayerStats {
+  private wallHealth: number;
+  readonly maxWallHealth: number;
+
+  constructor(maxWallHealth: number) {
+    this.maxWallHealth = maxWallHealth;
+    this.wallHealth = maxWallHealth;
+  }
+
+  takeDamage(amount = 1): number {
+    this.wallHealth = Math.max(0, this.wallHealth - amount);
+    return this.wallHealth;
+  }
+
+  getWallHealth(): number {
+    return this.wallHealth;
+  }
+
+  isDefeated(): boolean {
+    return this.wallHealth <= 0;
+  }
+
+  reset(): void {
+    this.wallHealth = this.maxWallHealth;
+  }
+}

--- a/src/states/MenuScene.ts
+++ b/src/states/MenuScene.ts
@@ -17,7 +17,7 @@ export class MenuScene extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.add
-      .text(width / 2, height / 2, '按下空格或点击开始挑战', {
+      .text(width / 2, height / 2, '按下空格或点击开始守城', {
         fontFamily: 'sans-serif',
         fontSize: '24px',
         color: '#cbd5f5',
@@ -25,7 +25,7 @@ export class MenuScene extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.add
-      .text(width / 2, height / 2 + 60, '在游戏中输入屏幕上的单词击败敌人', {
+      .text(width / 2, height / 2 + 60, '输入敌人单词射出箭矢，空格触发炸弹清屏', {
         fontFamily: 'sans-serif',
         fontSize: '18px',
         color: '#94a3b8',

--- a/src/states/PlayScene.ts
+++ b/src/states/PlayScene.ts
@@ -1,8 +1,14 @@
 import Phaser from 'phaser';
 import wordPool from '../config/wordPools/easy.json';
+import { defaultStage, StageConfig } from '../config/stageConfig';
 import { EventBus, Events } from '../core/EventBus';
 import { ScoreSystem } from '../systems/ScoreSystem';
 import { TypingProgress, TypingSystem } from '../systems/TypingSystem';
+import { BombSystem } from '../systems/BombSystem';
+import { Enemy, EnemyEliminationCause } from '../entities/Enemy';
+import { EnemySpawner } from '../systems/EnemySpawner';
+import { TrajectorySystem } from '../systems/TrajectorySystem';
+import { PlayerStats } from '../entities/PlayerStats';
 
 interface WordPoolData {
   language: string;
@@ -10,12 +16,28 @@ interface WordPoolData {
   words: string[];
 }
 
+interface BombClearSummary {
+  total: number;
+}
+
 export class PlayScene extends Phaser.Scene {
   private typingSystem!: TypingSystem;
   private scoreSystem!: ScoreSystem;
-  private activeWord = '';
-  private wordQueue: string[] = [];
-  private wordText!: Phaser.GameObjects.Text;
+  private bombSystem!: BombSystem;
+  private enemySpawner!: EnemySpawner;
+  private trajectorySystem!: TrajectorySystem;
+  private playerStats!: PlayerStats;
+
+  private readonly stageConfig: StageConfig = defaultStage;
+  private activeEnemies: Enemy[] = [];
+  private currentEnemy?: Enemy;
+  private defeatedCount = 0;
+  private stageFinished = false;
+  private breachY = 0;
+
+  private ranger!: Phaser.GameObjects.Rectangle;
+  private wall!: Phaser.GameObjects.Rectangle;
+  private targetWordText!: Phaser.GameObjects.Text;
   private inputText!: Phaser.GameObjects.Text;
 
   constructor() {
@@ -23,8 +45,18 @@ export class PlayScene extends Phaser.Scene {
   }
 
   create(): void {
+    this.stageFinished = false;
+    this.defeatedCount = 0;
+    this.activeEnemies = [];
+
     this.scoreSystem = new ScoreSystem();
+    this.playerStats = new PlayerStats(this.stageConfig.wall.maxHp);
+    this.bombSystem = new BombSystem(this.stageConfig.bombs);
+    this.trajectorySystem = new TrajectorySystem();
+
     this.ensureUIScene();
+    this.breachY = this.scale.height - 120;
+    this.setupBattlefield();
     this.setupTexts();
 
     this.typingSystem = new TypingSystem(this);
@@ -32,20 +64,46 @@ export class PlayScene extends Phaser.Scene {
     this.typingSystem.on('complete', this.handleTypingComplete, this);
     this.typingSystem.on('mistake', this.handleTypingMistake, this);
 
+    const pool = wordPool as WordPoolData;
+    this.enemySpawner = new EnemySpawner(
+      this,
+      this.stageConfig.spawn,
+      pool.words,
+      this.breachY,
+      this.stageConfig.dangerZone,
+    );
+    this.enemySpawner.on('spawn', this.handleEnemySpawn, this);
+
+    EventBus.emit(Events.ScoreUpdated, this.scoreSystem.summary());
+    EventBus.emit(Events.DisplayMessage, '敌人来袭，保卫城墙！');
+    EventBus.emit(Events.WallStatusUpdated, {
+      current: this.playerStats.getWallHealth(),
+      max: this.playerStats.maxWallHealth,
+    });
+
+    this.input.keyboard?.on('keydown-ESC', this.returnToMenu, this);
+    this.input.keyboard?.on('keydown-SPACE', this.tryActivateBomb, this);
+
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.typingSystem.off('progress', this.handleTypingProgress, this);
       this.typingSystem.off('complete', this.handleTypingComplete, this);
       this.typingSystem.off('mistake', this.handleTypingMistake, this);
       this.typingSystem.destroy();
+      this.enemySpawner.off('spawn', this.handleEnemySpawn, this);
       this.input.keyboard?.off('keydown-ESC', this.returnToMenu, this);
+      this.input.keyboard?.off('keydown-SPACE', this.tryActivateBomb, this);
     });
+  }
 
-    this.wordQueue = this.shuffleWords(wordPool as WordPoolData);
-    EventBus.emit(Events.ScoreUpdated, this.scoreSystem.summary());
-    EventBus.emit(Events.DisplayMessage, '保持专注，准备迎战！');
-    this.nextWord();
+  update(_: number, delta: number): void {
+    if (this.stageFinished) {
+      return;
+    }
 
-    this.input.keyboard?.on('keydown-ESC', this.returnToMenu, this);
+    this.enemySpawner.update(delta, this.activeEnemies.length);
+    this.trajectorySystem.update(delta);
+    this.bombSystem.update(delta);
+    this.checkForStageCompletion();
   }
 
   private ensureUIScene(): void {
@@ -56,79 +114,262 @@ export class PlayScene extends Phaser.Scene {
     }
   }
 
-  private setupTexts(): void {
+  private setupBattlefield(): void {
     const { width, height } = this.scale;
     this.add
-      .text(width / 2, 120, '输入出现的单词并按顺序击败所有敌人', {
+      .rectangle(width / 2, height / 2, width, height, 0x0f172a)
+      .setDepth(-5);
+
+    this.add
+      .rectangle(width / 2, height - 200, width, 180, 0x1e293b, 0.6)
+      .setDepth(-4);
+
+    this.wall = this.add
+      .rectangle(width / 2, this.breachY + 60, width, 120, 0x334155)
+      .setStrokeStyle(4, 0x475569)
+      .setDepth(-3);
+
+    const parapetWidth = 80;
+    for (let i = 0; i < width / parapetWidth; i += 1) {
+      this.add
+        .rectangle(40 + i * parapetWidth, this.breachY - 60, parapetWidth - 12, 36, 0x1f2937)
+        .setDepth(-2);
+    }
+
+    this.ranger = this.add
+      .rectangle(width / 2, this.breachY - 28, 36, 64, 0xe2e8f0)
+      .setStrokeStyle(2, 0xcbd5f5)
+      .setDepth(-1);
+
+    this.add
+      .text(width / 2, 64, '输入目标敌人单词发射箭矢，空格键释放炸弹', {
         fontFamily: 'sans-serif',
-        fontSize: '20px',
+        fontSize: '22px',
         color: '#cbd5f5',
       })
       .setOrigin(0.5);
+  }
 
-    this.wordText = this.add
-      .text(width / 2, height / 2 - 30, '', {
+  private setupTexts(): void {
+    const { width } = this.scale;
+    this.targetWordText = this.add
+      .text(width / 2, 120, '', {
         fontFamily: 'monospace',
-        fontSize: '64px',
+        fontSize: '56px',
         color: '#f8fafc',
       })
       .setOrigin(0.5);
 
     this.inputText = this.add
-      .text(width / 2, height / 2 + 40, '', {
+      .text(width / 2, 188, '', {
         fontFamily: 'monospace',
-        fontSize: '48px',
+        fontSize: '42px',
         color: '#38bdf8',
       })
       .setOrigin(0.5);
   }
 
-  private shuffleWords(data: WordPoolData): string[] {
-    const pool = [...data.words];
-    Phaser.Utils.Array.Shuffle(pool);
-    return pool;
+  private handleEnemySpawn(enemy: Enemy): void {
+    enemy.setDepth(5);
+    enemy.setProgress(0);
+    this.activeEnemies.push(enemy);
+    this.trajectorySystem.register(enemy);
+
+    enemy.once('eliminated', ({ cause }: { cause: EnemyEliminationCause }) => {
+      this.handleEnemyEliminated(enemy, cause);
+    });
+    enemy.once('breached', () => {
+      this.handleEnemyBreach(enemy);
+    });
+
+    this.refreshTargetSelection();
   }
 
-  private nextWord(): void {
-    if (this.wordQueue.length === 0) {
-      this.finishRound();
+  private handleEnemyEliminated(enemy: Enemy, cause: EnemyEliminationCause): void {
+    this.removeEnemy(enemy);
+    this.defeatedCount += 1;
+
+    if (cause === 'arrow') {
+      EventBus.emit(Events.DisplayMessage, '箭矢命中，敌人坠落！');
+    }
+
+    this.refreshTargetSelection();
+    this.checkForStageCompletion();
+  }
+
+  private handleEnemyBreach(enemy: Enemy): void {
+    if (this.stageFinished) {
       return;
     }
 
-    this.activeWord = this.wordQueue.pop() ?? '';
-    this.wordText.setText(this.activeWord);
+    this.removeEnemy(enemy);
+    const remaining = this.playerStats.takeDamage(1);
+    this.scoreSystem.registerBreach();
+    this.bombSystem.registerCombo(this.scoreSystem.getCombo());
+    EventBus.emit(Events.WallStatusUpdated, {
+      current: remaining,
+      max: this.playerStats.maxWallHealth,
+    });
+    EventBus.emit(Events.DisplayMessage, '敌人撞击城墙，注意防守！');
+
+    if (this.playerStats.isDefeated()) {
+      this.finishRound(false);
+      return;
+    }
+
+    this.refreshTargetSelection();
+  }
+
+  private refreshTargetSelection(): void {
+    const nextTarget = this.pickNextTarget();
+    if (nextTarget === this.currentEnemy) {
+      return;
+    }
+
+    if (this.currentEnemy) {
+      this.currentEnemy.markAsTargeted(false);
+    }
+
+    this.currentEnemy = nextTarget;
+
+    if (!nextTarget) {
+      this.typingSystem.setTarget('');
+      this.targetWordText.setText('');
+      this.inputText.setText('');
+      this.inputText.setColor('#38bdf8');
+      return;
+    }
+
+    nextTarget.markAsTargeted(true);
+    nextTarget.setProgress(0);
+    this.typingSystem.setTarget(nextTarget.word);
+    this.targetWordText.setText(nextTarget.word);
     this.inputText.setText('');
-    this.typingSystem.setTarget(this.activeWord);
-    EventBus.emit(Events.WordChanged, this.activeWord);
+    this.inputText.setColor('#38bdf8');
+    EventBus.emit(Events.WordChanged, nextTarget.word);
+  }
+
+  private pickNextTarget(): Enemy | undefined {
+    if (this.activeEnemies.length === 0) {
+      return undefined;
+    }
+
+    const sorted = [...this.activeEnemies];
+    sorted.sort((a, b) => b.y - a.y);
+    return sorted[0];
   }
 
   private handleTypingProgress(progress: TypingProgress): void {
     this.inputText.setText(progress.input);
     this.inputText.setColor(progress.isMistake ? '#f87171' : '#38bdf8');
+    if (this.currentEnemy) {
+      this.currentEnemy.setProgress(progress.input.length);
+    }
   }
 
   private handleTypingComplete(word: string): void {
+    if (!this.currentEnemy) {
+      return;
+    }
+
+    const target = this.currentEnemy;
     this.scoreSystem.registerSuccess(word.length);
-    EventBus.emit(Events.DisplayMessage, `击败敌人：${word}`);
-    this.nextWord();
+    this.bombSystem.registerCombo(this.scoreSystem.getCombo());
+    target.setProgress(word.length);
+    this.typingSystem.setTarget('');
+    this.launchArrow(target);
   }
 
   private handleTypingMistake(): void {
     this.scoreSystem.registerMistake();
+    this.bombSystem.registerCombo(this.scoreSystem.getCombo());
     EventBus.emit(Events.DisplayMessage, '输入错误，连击已重置');
   }
 
-  private finishRound(): void {
+  private launchArrow(target: Enemy): void {
+    const arrow = this.add
+      .rectangle(this.ranger.x, this.ranger.y - 36, 6, 32, 0xfbbf24)
+      .setOrigin(0.5, 1)
+      .setDepth(8);
+
+    this.tweens.add({
+      targets: arrow,
+      x: target.x,
+      y: target.y,
+      duration: 220,
+      ease: Phaser.Math.Easing.Cubic.Out,
+      onComplete: () => {
+        target.hitByArrow();
+        arrow.destroy();
+      },
+    });
+  }
+
+  private tryActivateBomb(event: KeyboardEvent): void {
+    event.preventDefault();
+    if (this.activeEnemies.length === 0) {
+      EventBus.emit(Events.DisplayMessage, '暂时没有敌人，炸弹保持待命');
+      return;
+    }
+
+    if (!this.bombSystem.canActivate() || !this.bombSystem.activate()) {
+      EventBus.emit(Events.DisplayMessage, '炸弹尚在冷却中');
+      return;
+    }
+
+    const targets = [...this.activeEnemies];
+    this.currentEnemy?.markAsTargeted(false);
+    this.currentEnemy = undefined;
     this.typingSystem.setTarget('');
-    EventBus.emit(Events.DisplayMessage, '所有敌人被击败，干得好！');
+    this.targetWordText.setText('');
+    this.inputText.setText('');
+
+    targets.forEach((enemy) => enemy.eliminateByBomb());
+
+    const summary: BombClearSummary = { total: targets.length };
+    this.scoreSystem.registerBombClear(summary.total);
+    EventBus.emit(Events.DisplayMessage, `炸弹清除了 ${summary.total} 名敌人！`);
+  }
+
+  private removeEnemy(enemy: Enemy): void {
+    this.trajectorySystem.unregister(enemy);
+    this.activeEnemies = this.activeEnemies.filter((active) => active !== enemy);
+    if (this.currentEnemy === enemy) {
+      this.currentEnemy = undefined;
+    }
+  }
+
+  private checkForStageCompletion(): void {
+    if (this.stageFinished) {
+      return;
+    }
+
+    if (this.defeatedCount >= this.stageConfig.spawn.total && this.activeEnemies.length === 0) {
+      this.finishRound(true);
+    }
+  }
+
+  private finishRound(success: boolean): void {
+    if (this.stageFinished) {
+      return;
+    }
+
+    this.stageFinished = true;
+    this.enemySpawner.stop();
+    this.typingSystem.setTarget('');
+
     const summary = this.scoreSystem.summary();
-    this.time.delayedCall(1200, () => {
+    EventBus.emit(Events.DisplayMessage, success ? '胜利！城墙安然无恙。' : '城墙沦陷，守城失败。');
+
+    this.time.delayedCall(900, () => {
       this.scene.stop('UIScene');
-      this.scene.start('ResultScene', { summary });
+      this.scene.start('ResultScene', { summary, success });
     });
   }
 
   private returnToMenu(): void {
+    this.stageFinished = true;
+    this.enemySpawner.stop();
     this.scene.stop('UIScene');
     this.scene.start('MenuScene');
   }

--- a/src/states/ResultScene.ts
+++ b/src/states/ResultScene.ts
@@ -3,6 +3,7 @@ import { ScoreSummary } from '../core/EventBus';
 
 interface ResultSceneData {
   summary: ScoreSummary;
+  success: boolean;
 }
 
 export class ResultScene extends Phaser.Scene {
@@ -16,8 +17,10 @@ export class ResultScene extends Phaser.Scene {
       ? Math.round(data.summary.accuracy * 100)
       : 100;
 
+    const title = data.success ? '守城成功' : '守城失败';
+
     this.add
-      .text(width / 2, height / 2 - 100, '战斗总结', {
+      .text(width / 2, height / 2 - 110, title, {
         fontFamily: 'sans-serif',
         fontSize: '42px',
         color: '#f1f5f9',
@@ -27,8 +30,10 @@ export class ResultScene extends Phaser.Scene {
     const lines = [
       `得分：${data.summary.score}`,
       `连击：${data.summary.combo}`,
-      `击败敌人：${data.summary.wordsCompleted}`,
+      `击败敌人：${data.summary.enemiesDefeated}（箭矢 ${data.summary.typedEliminations} / 炸弹 ${data.summary.bombEliminations}）`,
       `准确率：${accuracy}%`,
+      `炸弹使用：${data.summary.bombsUsed}`,
+      `城墙受损：${data.summary.breaches}`,
     ];
 
     this.add

--- a/src/systems/BombSystem.ts
+++ b/src/systems/BombSystem.ts
@@ -1,0 +1,93 @@
+import { EventBus, Events, BombStatus } from '../core/EventBus';
+
+export interface BombConfig {
+  initial: number;
+  max: number;
+  cooldown: number;
+  comboThreshold: number;
+}
+
+export class BombSystem {
+  private charges: number;
+  private readonly maxCharges: number;
+  private readonly cooldown: number;
+  private cooldownRemaining = 0;
+  private readonly comboThreshold: number;
+  private lastAwardedCombo = 0;
+
+  constructor(config: BombConfig) {
+    this.charges = config.initial;
+    this.maxCharges = config.max;
+    this.cooldown = config.cooldown;
+    this.comboThreshold = Math.max(1, config.comboThreshold);
+    this.publishStatus();
+  }
+
+  update(delta: number): void {
+    if (this.cooldownRemaining <= 0) {
+      return;
+    }
+
+    this.cooldownRemaining = Math.max(0, this.cooldownRemaining - delta);
+    if (this.cooldownRemaining === 0 && this.charges < this.maxCharges) {
+      this.charges += 1;
+      this.publishStatus();
+    } else {
+      this.publishStatus();
+    }
+  }
+
+  canActivate(): boolean {
+    return this.charges > 0;
+  }
+
+  activate(): boolean {
+    if (!this.canActivate()) {
+      return false;
+    }
+
+    this.charges -= 1;
+    this.cooldownRemaining = this.cooldown;
+    this.publishStatus();
+    EventBus.emit(Events.BombActivated);
+    return true;
+  }
+
+  registerCombo(combo: number): void {
+    if (combo === 0) {
+      this.lastAwardedCombo = 0;
+      return;
+    }
+
+    if (combo % this.comboThreshold !== 0) {
+      return;
+    }
+
+    if (combo === this.lastAwardedCombo) {
+      return;
+    }
+
+    this.lastAwardedCombo = combo;
+    this.grantCharge();
+  }
+
+  private grantCharge(): void {
+    if (this.charges >= this.maxCharges) {
+      return;
+    }
+
+    this.charges += 1;
+    this.cooldownRemaining = 0;
+    this.publishStatus();
+  }
+
+  private publishStatus(): void {
+    const status: BombStatus = {
+      charges: this.charges,
+      maxCharges: this.maxCharges,
+      cooldownRemaining: this.cooldownRemaining,
+      cooldown: this.cooldown,
+    };
+    EventBus.emit(Events.BombStatusUpdated, status);
+  }
+}

--- a/src/systems/EnemySpawner.ts
+++ b/src/systems/EnemySpawner.ts
@@ -1,0 +1,91 @@
+import Phaser from 'phaser';
+import { Enemy, EnemyPath } from '../entities/Enemy';
+import type { SpawnConfig } from '../config/stageConfig';
+
+export class EnemySpawner extends Phaser.Events.EventEmitter {
+  private readonly config: SpawnConfig;
+  private readonly scene: Phaser.Scene;
+  private readonly breachY: number;
+  private readonly dangerZone: number;
+  private readonly baseWords: string[];
+  private wordBag: string[];
+  private spawnTimer = 0;
+  private spawnedCount = 0;
+  private active = true;
+
+  constructor(
+    scene: Phaser.Scene,
+    config: SpawnConfig,
+    wordPool: string[],
+    breachY: number,
+    dangerZone: number,
+  ) {
+    super();
+    this.scene = scene;
+    this.config = config;
+    this.breachY = breachY;
+    this.dangerZone = dangerZone;
+    this.baseWords = wordPool.length > 0 ? [...wordPool] : ['defend', 'castle', 'arrow'];
+    this.wordBag = this.shuffleWords(this.baseWords);
+    this.spawnTimer = config.interval * 0.5;
+  }
+
+  update(delta: number, activeEnemies: number): void {
+    if (!this.active) {
+      return;
+    }
+
+    if (this.spawnedCount >= this.config.total) {
+      this.active = false;
+      return;
+    }
+
+    if (activeEnemies >= this.config.maxConcurrent) {
+      return;
+    }
+
+    this.spawnTimer -= delta;
+    if (this.spawnTimer > 0) {
+      return;
+    }
+
+    this.spawnTimer = this.config.interval;
+    this.spawnEnemy();
+  }
+
+  stop(): void {
+    this.active = false;
+  }
+
+  private spawnEnemy(): void {
+    const word = this.nextWord();
+    const path = Phaser.Utils.Array.GetRandom(this.config.paths);
+    const x = Phaser.Math.Between(140, this.scene.scale.width - 140);
+    const speed = Phaser.Math.FloatBetween(this.config.speed.min, this.config.speed.max);
+
+    const enemy = new Enemy(this.scene, x, -80, {
+      word,
+      path: path as EnemyPath,
+      speed,
+      breachY: this.breachY,
+      dangerZone: this.dangerZone,
+    });
+
+    this.spawnedCount += 1;
+    this.emit('spawn', enemy);
+  }
+
+  private nextWord(): string {
+    if (this.wordBag.length === 0) {
+      this.wordBag = this.shuffleWords(this.baseWords);
+    }
+
+    return this.wordBag.pop() ?? 'enemy';
+  }
+
+  private shuffleWords(words: string[]): string[] {
+    const pool = [...words];
+    Phaser.Utils.Array.Shuffle(pool);
+    return pool;
+  }
+}

--- a/src/systems/ScoreSystem.ts
+++ b/src/systems/ScoreSystem.ts
@@ -5,10 +5,13 @@ export class ScoreSystem {
   private combo = 0;
   private totalTypedChars = 0;
   private mistakes = 0;
-  private wordsCompleted = 0;
+  private typedEliminations = 0;
+  private bombEliminations = 0;
+  private bombsUsed = 0;
+  private breaches = 0;
 
   registerSuccess(wordLength: number): void {
-    this.wordsCompleted += 1;
+    this.typedEliminations += 1;
     this.totalTypedChars += wordLength;
     this.combo += 1;
     const comboMultiplier = 1 + Math.floor(this.combo / 5) * 0.2;
@@ -22,12 +25,38 @@ export class ScoreSystem {
     this.publishUpdate();
   }
 
+  registerBombClear(eliminated: number): void {
+    if (eliminated <= 0) {
+      return;
+    }
+
+    this.bombsUsed += 1;
+    this.bombEliminations += eliminated;
+    this.score += eliminated * 15;
+    this.publishUpdate();
+  }
+
+  registerBreach(): void {
+    this.breaches += 1;
+    this.mistakes += 1;
+    this.combo = 0;
+    this.publishUpdate();
+  }
+
+  getCombo(): number {
+    return this.combo;
+  }
+
   summary(): ScoreSummary {
     return {
       score: this.score,
       combo: this.combo,
       accuracy: this.calculateAccuracy(),
-      wordsCompleted: this.wordsCompleted,
+      enemiesDefeated: this.typedEliminations + this.bombEliminations,
+      typedEliminations: this.typedEliminations,
+      bombEliminations: this.bombEliminations,
+      bombsUsed: this.bombsUsed,
+      breaches: this.breaches,
     };
   }
 

--- a/src/systems/TrajectorySystem.ts
+++ b/src/systems/TrajectorySystem.ts
@@ -1,0 +1,17 @@
+import { Enemy } from '../entities/Enemy';
+
+export class TrajectorySystem {
+  private readonly enemies = new Set<Enemy>();
+
+  register(enemy: Enemy): void {
+    this.enemies.add(enemy);
+  }
+
+  unregister(enemy: Enemy): void {
+    this.enemies.delete(enemy);
+  }
+
+  update(delta: number): void {
+    this.enemies.forEach((enemy) => enemy.advance(delta));
+  }
+}

--- a/src/systems/TypingSystem.ts
+++ b/src/systems/TypingSystem.ts
@@ -33,10 +33,6 @@ export class TypingSystem extends Phaser.Events.EventEmitter {
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
-    if (!this.targetWord) {
-      return;
-    }
-
     if (event.key === 'Backspace') {
       event.preventDefault();
       if (this.inputBuffer.length > 0) {
@@ -47,7 +43,22 @@ export class TypingSystem extends Phaser.Events.EventEmitter {
       return;
     }
 
+    if (!this.targetWord) {
+      return;
+    }
+
     if (event.key.length > 1) {
+      if (event.key === 'Escape') {
+        return;
+      }
+      return;
+    }
+
+    if (event.key.trim().length === 0) {
+      return;
+    }
+
+    if (!/^[a-z0-9]$/i.test(event.key)) {
       return;
     }
 

--- a/设计文档.md
+++ b/设计文档.md
@@ -2,6 +2,7 @@
 
 ## 1. 项目概览
 - **名称**：Little Key Rangers（暂定）
+- **主题概念**：小游侠立于城墙之上，使用弓箭射击带有单词的下落敌人，守护城池。
 - **类型**：基于浏览器的 2D 打字闯关/无尽小游戏。
 - **目标平台**：桌面端现代浏览器（Chromium、Firefox、Safari）。
 - **主要引擎**：Phaser 3。
@@ -9,10 +10,11 @@
 - **目标用户**：希望通过轻松的小游戏锻炼打字速度与准确率的休闲玩家。
 
 ## 2. 核心玩法与体验
-1. 玩家在限定生命值或倒计时约束下，通过键入屏幕上的单词击败敌人或阻止障碍靠近。
-2. 正确输入单词可击败敌人、累积连击、获得分数奖励；输入错误会重置连击、扣除生命或时间。
-3. 游戏提供多个关卡与词库难度，逐步提升单词长度、敌人速度与特殊机制。
-4. 设有排行榜、成就与练习模式，鼓励玩家重复挑战、提升打字技巧。
+1. 玩家操纵城墙上的游侠，通过键入敌人身上的单词来放箭，射中后击落敌人。
+2. 敌人携带不同单词沿预定路径自天空落向城墙，若未在入侵前击倒则对城墙造成伤害。
+3. 击中敌人会触发箭矢命中特效、连击与得分奖励；输入错误会使连击重置并给予震动/警示反馈。
+4. 特殊敌人或道具会掉落“炸弹”，触发后清除屏幕内所有敌人并重置压力。
+5. 游戏提供多种关卡、词库与难度组合，随波次提升敌人速度、路径变化与炸弹需求。
 
 ## 3. 系统架构与目录规划
 ```
@@ -36,6 +38,9 @@
     StorageService.ts
   /entities
     Enemy.ts
+    Ranger.ts
+    Arrow.ts
+    Bomb.ts
     PlayerStats.ts
     WordBubble.ts
   /states
@@ -49,6 +54,8 @@
     EnemySpawner.ts
     ComboSystem.ts
     ScoreSystem.ts
+    BombSystem.ts
+    TrajectorySystem.ts
   /ui
     components/
       Button.ts
@@ -61,115 +68,171 @@
 - **核心模块划分**
   - `core`：Phaser 配置、全局系统与辅助类。
   - `states`：游戏状态/场景（菜单、游戏、结算等）。
-  - `systems`：与场景解耦的逻辑系统（输入、评分、生成等）。
-  - `entities`：游戏实体的数据与行为描述。
-  - `config`：词库、关卡、任务等数据配置。
+  - `systems`：与场景解耦的逻辑系统（输入、敌人轨迹、炸弹、评分等）。
+  - `entities`：游侠、敌人、箭矢、炸弹等游戏实体的数据与行为描述。
+  - `config`：词库、关卡、敌人路径、炸弹规则等数据配置。
   - `ui`：UI 组件封装（按钮、进度条、对话框等）。
 
+- **敌人下落路径与行为**
+  - `TrajectorySystem` 读取 `stages.json` 中的路径定义（直线、抛物、曲线），计算敌人在每帧的位移与朝向。
+  - 敌人包含多段行为状态：入场、携带单词、受击、坠落、撞击城墙；状态变化通过事件广播给 UI 与音效。
+
+- **命中判定**
+  - `TypingSystem` 将当前输入与敌人单词逐字符比对，当单词完成时触发 `arrow:release` 事件。
+  - `Arrow` 实体沿游侠到敌人的弹道飞行，命中后调用敌人 `takeHit()`，触发爆裂动画和得分。
+  - 支持多箭排队：若有多个敌人完成输入，则依照完成顺序依次射出，避免误判。
+
+- **炸弹清屏机制**
+  - `BombSystem` 监听炸弹拾取与触发事件，可来自特殊敌人、连击奖励或关卡脚本。
+  - 激活炸弹时播放蓄力动画，随后对所有在场敌人调用 `forceEliminate()`，并对 HUD 输出冷却/次数更新。
+
+- **词库与敌人绑定关系**
+  - `EnemySpawner` 根据关卡配置从对应 `wordPool` 中取词，并写入敌人实例。
+  - 支持同一波敌人使用主题词组；特殊敌人可绑定特定难度或语法类别，增强学习目标。
+  - 词库与敌人类型映射存于 `stages.json` 的 `wordGroups` 字段，方便扩展。
+
 ## 4. 场景与状态流程
-1. **BootScene**：预加载资源（图片、音效、字体、配置 JSON），完成后跳转到 `MenuScene`。
-2. **MenuScene**：展示标题、模式选择、设置按钮。点击“开始游戏”或按键后进入 `PlayScene` 或其他模式。
-3. **PlayScene**：根据选定关卡配置生成敌人，绑定 `UIScene` 显示生命、得分、连击等 HUD 信息。
-4. **PauseScene**：暂停界面，显示继续、重开、返回主菜单等选项。
-5. **ResultScene**：展示统计数据（分数、准确率、连击、奖励），存档并提供分享/重玩按钮。
-6. **EndlessScene**：无尽模式，敌人随时间加速，持续挑战直至失败。
+1. **BootScene**：预加载游侠、城墙、箭矢、敌人、炸弹等资源（图片、音效、字体、配置 JSON），完成后跳转到 `MenuScene`。
+2. **MenuScene**：展示主题城墙背景、模式选择、词库说明。点击“开始守城”进入 `PlayScene` 或选择无尽模式进入 `EndlessScene`。
+3. **PlayScene**：
+   - 初始化游侠站位、城墙耐久度、HUD；
+   - 调度 `EnemySpawner` 按波次自顶部生成敌人，调用 `TrajectorySystem` 控制敌人下落路径与速度；
+   - `TypingSystem` 处理输入并触发箭矢发射，`BombSystem` 维护炸弹充能与触发；
+   - 敌人落地时触发城墙受击动画，若耐久归零则结束关卡。
+4. **PauseScene**：暂停并遮罩场景，提供继续、重开、返回主菜单选项。
+5. **ResultScene**：展示守城成果（得分、准确率、最高连击、炸弹使用次数），记录词库表现并提供重试。
+6. **EndlessScene**：无尽模式持续生成敌人，逐步提高下落速度与路径复杂度，炸弹冷却缩短以应对高压。
 
 ## 5. 核心系统设计
 ### 5.1 TypingSystem（输入系统）
-- 监听键盘事件，维护玩家当前输入缓冲。
-- 与当前目标单词对比，高亮正确字符，输入错误提供反馈（声音/视觉）。
-- 支持 Backspace 撤销、特殊键映射以及多目标切换（如 Tab）。
-- 通过事件触发 `typing:correct`、`typing:miss`、`typing:complete` 等反馈。
+- 监听键盘事件，维护玩家当前目标敌人队列。
+- 与敌人单词逐字符对比，高亮正确部分，错误时闪烁敌人并播放警告音。
+- 单词完成后触发 `arrow:release`，向 `Arrow` 对象池申请箭矢实体。
+- 支持 Backspace 撤销、Tab 切换目标、特殊键触发炸弹。
 
 ### 5.2 EnemySpawner（敌人生成）
-- 按关卡配置（波次、路径、速度）生成敌人对象。
-- 控制同屏敌人数、重用对象池，支持 Boss 或特殊敌人。
-- 敌人到达终点触发伤害或扣时，通过事件通知 `PlayerStats`。
+- 按关卡配置（波次、路径、速度、携带词组）生成敌人对象。
+- 控制同屏敌人数、重用对象池，支持携带炸弹的特殊敌人。
+- 敌人到达城墙触发 `enemy:breached`，导致城墙耐久减少与 HUD 更新。
 
-### 5.3 Score & Combo System（评分与连击）
-- 成功击败敌人累积分数，连击提升倍率。
-- 统计输入字符数、错误数，用于计算准确率、WPM、最高连击。
-- 连击达到阈值触发奖励（清屏、护盾、分数加成）。
+### 5.3 TrajectorySystem（轨迹系统）
+- 解析路径样式（直线、S 曲线、随机漂移）并提供位置插值。
+- 支持下落过程中改变速度或触发停顿，为 Boss 设计预留接口。
 
-### 5.4 PlayerStats（玩家状态）
-- 维护生命、护盾、倒计时、技能能量等。
-- 提供接口响应敌人攻击、输入失误等事件，触发游戏结束条件。
+### 5.4 Arrow/Bomb System（箭矢与炸弹系统）
+- 箭矢根据游侠位置与敌人位置计算飞行时间，命中后触发敌人坠落与得分。
+- 炸弹可通过快捷键或 UI 按钮触发，瞬间对敌人数组应用清除效果，伴随屏幕闪光与音浪。
 
-### 5.5 AudioManager
-- 统一管理背景音乐与音效，支持音量调节、静音。
-- 提供 `playKeySound`、`playSuccess`、`playFail` 等封装方法。
+### 5.5 Score & Combo System（评分与连击）
+- 击败敌人累积分数，连击提升倍率，炸弹击杀按敌人数额外奖励。
+- 统计输入字符数、错误数，用于计算准确率、WPM、最高连击与炸弹使用效率。
+- 连击达到阈值可自动掉落炸弹或提供箭矢强化。
 
-### 5.6 StorageService
-- 基于 LocalStorage 保存最高分、最佳准确率、连击纪录、设置与解锁内容。
-- 预留接口扩展云端同步或排行榜服务。
+### 5.6 PlayerStats（玩家状态）
+- 维护城墙耐久、游侠护盾、炸弹库存、技能冷却等。
+- 提供接口响应敌人攻击、输入失误、炸弹触发，并判断游戏失败条件。
+
+### 5.7 AudioManager
+- 统一管理背景音乐、箭矢、炸弹、敌人坠落等音效，支持音量调节与静音。
+- 对命中、连击、炸弹释放设立独立声道，避免声音遮蔽。
+
+### 5.8 StorageService
+- 基于 LocalStorage 保存最高分、最佳准确率、炸弹使用记录、设置与解锁内容。
+- 预留接口扩展云端排行榜或教学模式数据同步。
 
 ## 6. 数据配置
 ### 6.1 关卡配置
-- `config/stages.json` 定义背景、音乐、敌人波次、胜负条件等。
+- `config/stages.json` 定义背景、音乐、敌人波次、路径与炸弹掉落概率等。
 - 示例：
 ```json
 {
   "id": "stage1",
-  "name": "训练场",
-  "background": "bg_training",
+  "name": "城门训练场",
+  "background": "bg_wall",
   "music": "track_easy",
   "wordPool": "easy",
   "spawn": {
     "waves": [
       { "time": 0, "count": 5, "interval": 1500, "path": "straight" },
-      { "time": 15000, "count": 8, "interval": 1200, "path": "zigzag" }
+      { "time": 15000, "count": 6, "interval": 1200, "path": "zigzag" },
+      { "time": 28000, "count": 1, "interval": 0, "path": "boss", "type": "bombCarrier" }
     ],
     "maxConcurrent": 4
   },
-  "winCondition": { "type": "defeatAll" },
-  "lossCondition": { "type": "hp", "hp": 3 }
+  "bomb": {
+    "initial": 1,
+    "cooldown": 20000,
+    "comboReward": 15
+  },
+  "winCondition": { "type": "defend", "duration": 60000 },
+  "lossCondition": { "type": "wall", "hp": 3 }
 }
 ```
 
 ### 6.2 词库配置
-- `config/wordPools/*.json` 管理不同难度与语言的词库。
+- `config/wordPools/*.json` 管理不同难度与语言的词库，并附带主题标签。
 - 示例 `easy.json`：
 ```json
 {
   "language": "en",
   "difficulty": "easy",
-  "words": ["cat", "sun", "tree", "code", "game"]
+  "tags": ["castle", "basic"],
+  "words": ["bow", "wall", "hero", "guard", "shield"]
 }
 ```
 
-### 6.3 成就/任务
-- 可选 `config/achievements.json`，记录解锁条件与奖励。
-- 示例：`{"id": "combo_50", "desc": "连击达到50", "reward": "badge_combo_master"}`。
+### 6.3 敌人与词库绑定
+- `stages.json` 中的 `wordGroups` 数组允许指定“飞龙敌人使用长度≥6 的单词”“炸弹携带者使用数字词”等规则。
+- `EnemySpawner` 根据敌人类型读取绑定规则，保证教学目标与敌人表现一致。
 
-## 7. UI 与音效
-- **HUD**：显示生命/时间、分数、连击、WPM、准确率、技能冷却。
-- **菜单**：标题、模式选择、设置（音量、语言、主题、词库管理）。
-- **反馈**：输入正确/错误的视觉与听觉效果、连击奖励动画、敌人击败特效。
+### 6.4 成就/任务
+- 可选 `config/achievements.json` 记录解锁条件与奖励，如 `{"id": "bomb_master", "desc": "单局使用炸弹清除20名敌人", "reward": "title_bomb_master"}`。
+
+## 7. UI、HUD、音效与美术表现
+- **HUD**：
+  - 显示城墙耐久度、游侠护盾、当前连击、分数、WPM、炸弹库存与冷却条。
+  - 当敌人接近城墙时 HUD 边框变红闪烁；炸弹可用时高亮提示。
+  - 炸弹触发后 HUD 显示“城墙安然无恙”文字动画并重置敌人警报。
+- **音效**：
+  - 游侠拉弓、放箭、箭矢命中各自拥有节奏分明的音效，命中长词给予更厚重反馈。
+  - 敌人撞击城墙播放沉重撞击声；炸弹触发播放低频蓄力+爆破声并伴随观众欢呼。
+  - 连击提升与警告状态使用短促提示音，保证玩家即时掌握战况。
+- **美术**：
+  - 背景展现坚固城墙与远处城镇，随关卡更换时间与天气。
+  - 游侠立于城垛，放箭时有拉弓姿态与箭矢光迹；高连击时衣着发光或披风飘扬。
+  - 敌人样式体现所携带词汇主题，坠落时有烟尘或破碎特效。
+  - 炸弹以魔法水晶或火药桶形式出现，激活时屏幕中央爆发冲击波并清除敌人残影。
 
 ## 8. 游戏循环示意
 ```ts
 class PlayScene extends Phaser.Scene {
   private typingSystem!: TypingSystem;
   private enemySpawner!: EnemySpawner;
+  private trajectorySystem!: TrajectorySystem;
   private scoreSystem!: ScoreSystem;
   private playerStats!: PlayerStats;
+  private bombSystem!: BombSystem;
 
   create(config: StageConfig) {
-    this.playerStats = new PlayerStats(config.lossCondition);
-    this.enemySpawner = new EnemySpawner(this, config.spawn, config.wordPool);
-    this.typingSystem = new TypingSystem(this.input.keyboard, this.enemySpawner);
+    this.playerStats = new PlayerStats(config.lossCondition, config.bomb);
+    this.trajectorySystem = new TrajectorySystem(config.spawn.paths);
+    this.enemySpawner = new EnemySpawner(this, config.spawn, config.wordPool, this.trajectorySystem);
+    this.typingSystem = new TypingSystem(this.input.keyboard, this.enemySpawner, this.bombSystem);
     this.scoreSystem = new ScoreSystem();
+    this.bombSystem = new BombSystem(config.bomb);
 
     EventBus.on('enemy:cleared', this.onEnemyCleared, this);
     EventBus.on('enemy:breached', this.onEnemyBreached, this);
     EventBus.on('typing:miss', this.onMiss, this);
+    EventBus.on('bomb:activated', this.onBombActivated, this);
 
-    this.scene.run('UIScene', { stats: this.playerStats });
+    this.scene.run('UIScene', { stats: this.playerStats, bomb: this.bombSystem });
   }
 
   update(time: number, delta: number) {
     this.enemySpawner.update(time, delta);
     this.playerStats.update(delta);
+    this.bombSystem.update(delta);
 
     if (this.playerStats.isDefeated()) {
       this.scene.stop('UIScene');
@@ -180,26 +243,28 @@ class PlayScene extends Phaser.Scene {
 ```
 
 ## 9. 里程碑规划
-1. **原型阶段**
-   - 初始化项目、场景切换、基础输入判定与单关卡原型。
-2. **核心功能实现**
-   - 完成 TypingSystem、EnemySpawner、Score/Combo、HUD UI。
-   - 实现音效、动画反馈。
-3. **内容扩展与打磨**
-   - 增加关卡配置、难度曲线、成就与排行榜。
-   - 丰富词库、支持多语言与练习模式。
-4. **优化与发布**
-   - 性能优化（对象池、粒子控制），完善响应式布局。
-   - 打包部署、编写用户指南。
+1. **前期准备与框架搭建**
+   - 初始化 Vite + Phaser + TypeScript 项目结构与资源加载流程。
+   - 实现 BootScene、MenuScene、基础 UI 与全局事件总线。
+2. **核心战斗机制实现**
+   - 完成 TypingSystem 与箭矢发射流程，确保正确输入即可命中敌人。
+   - 构建 EnemySpawner 与 TrajectorySystem，实现敌人下落与多路径支持。
+   - 引入 BombSystem 与 HUD 显示，支持手动触发炸弹并清除敌人。
+3. **内容扩展与数值调优**
+   - 丰富词库、关卡波次、敌人类型及炸弹掉落规则。
+   - 加入音效、美术特效、命中与警报反馈，完善敌人行为动画。
+4. **打磨与发布准备**
+   - 优化性能（对象池、轨迹计算）、强化设置与可访问性选项。
+   - 整合排行榜、成就与教学模式，完成打包部署与说明文档。
 
 ## 10. 可选扩展
-- 实时/异步多人竞速模式。
-- 自定义词库导入与数据分析（常错字母统计）。
-- 主题皮肤、角色收集系统。
+- 实时/异步守城竞速模式，与好友比拼守城时长。
+- 自定义词库导入与学习统计（常错词、复习计划）。
+- 主题皮肤、游侠装备进阶系统。
 - 移动端适配与触屏输入方案。
 
 ## 11. 下一步计划
-1. 初始化 Vite + Phaser + TypeScript 项目结构。
-2. 实现 BootScene、MenuScene、PlayScene 的最小可运行原型。
-3. 构建基础 TypingSystem、ScoreSystem 与 HUD。
-4. 按照设计文档逐步扩展敌人生成、关卡配置和音效等功能。
+1. 建立基本场景循环并渲染游侠、城墙与敌人原型。
+2. 实现输入命中→箭矢发射→敌人被击落的最小可行链路。
+3. 为炸弹提供 UI 触发、冷却与清屏反馈，确保基础体验完整。
+4. 根据测试结果迭代敌人路径、词库与音效表现。


### PR DESCRIPTION
## Summary
- add configurable stage, enemy, and bomb systems to drive falling word foes
- rework PlayScene with arrow attacks, bomb triggers, wall health, and dynamic targeting per design
- enhance HUD and result summaries with bomb, wall, and elimination statistics tied to the new score flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d098097ef083308d9ce5b90cc7be58