### PR TITLE
Implement stage progression, boss battles, and gameplay UI improvements

### DIFF
--- a/src/config/stages.ts
+++ b/src/config/stages.ts
@@ -1,0 +1,177 @@
+import { StageConfig } from './stageConfig';
+import easy from './wordPools/easy.json';
+import normal from './wordPools/normal.json';
+import hard from './wordPools/hard.json';
+
+export interface BossConfig {
+  name: string;
+  words: string[];
+  speed: number;
+  pushback: number;
+  damage: number;
+  spriteScale: number;
+}
+
+export interface StageDefinition {
+  id: number;
+  name: string;
+  description: string;
+  difficulty: 'easy' | 'normal' | 'hard';
+  wordPool: string[];
+  stageConfig: StageConfig;
+  dropRate: number;
+  boss: BossConfig;
+}
+
+const createStageConfig = (
+  overrides: Partial<StageConfig>,
+  base: StageConfig,
+): StageConfig => ({
+  wall: overrides.wall ?? base.wall,
+  dangerZone: overrides.dangerZone ?? base.dangerZone,
+  spawn: {
+    ...base.spawn,
+    ...(overrides.spawn ?? {}),
+    speed: overrides.spawn?.speed ?? base.spawn.speed,
+    paths: overrides.spawn?.paths ?? base.spawn.paths,
+  },
+  bombs: {
+    ...base.bombs,
+    ...(overrides.bombs ?? {}),
+  },
+});
+
+const baseStage: StageConfig = {
+  wall: { maxHp: 3 },
+  dangerZone: 140,
+  spawn: {
+    total: 18,
+    interval: 1500,
+    maxConcurrent: 4,
+    speed: { min: 80, max: 140 },
+    paths: ['straight', 'zigzag', 'drift'],
+  },
+  bombs: {
+    initial: 1,
+    max: 2,
+    cooldown: 20000,
+    comboThreshold: 6,
+  },
+};
+
+export const stages: StageDefinition[] = [
+  {
+    id: 1,
+    name: '城墙演练',
+    description: '轻度敌军压境，熟悉箭矢与炸弹的基础操控。',
+    difficulty: 'easy',
+    wordPool: easy.words,
+    stageConfig: createStageConfig(
+      {
+        wall: { maxHp: 4 },
+        spawn: {
+          total: 16,
+          interval: 1600,
+          maxConcurrent: 3,
+          speed: { min: 70, max: 120 },
+          paths: ['straight', 'drift'],
+        },
+        bombs: {
+          initial: 1,
+          max: 2,
+          cooldown: 18000,
+          comboThreshold: 5,
+        },
+      },
+      baseStage,
+    ),
+    dropRate: 0.25,
+    boss: {
+      name: '暗影侦察兵',
+      words: ['shadow', 'focus', 'valor'],
+      speed: 60,
+      pushback: 140,
+      damage: 2,
+      spriteScale: 1.1,
+    },
+  },
+  {
+    id: 2,
+    name: '暴风前线',
+    description: '更多敌人从各个角度袭来，保持冷静的节奏与准确度。',
+    difficulty: 'normal',
+    wordPool: normal.words,
+    stageConfig: createStageConfig(
+      {
+        wall: { maxHp: 4 },
+        spawn: {
+          total: 22,
+          interval: 1350,
+          maxConcurrent: 5,
+          speed: { min: 90, max: 150 },
+          paths: ['straight', 'zigzag', 'drift'],
+        },
+        bombs: {
+          initial: 1,
+          max: 3,
+          cooldown: 17000,
+          comboThreshold: 5,
+        },
+      },
+      baseStage,
+    ),
+    dropRate: 0.32,
+    boss: {
+      name: '风暴军需官',
+      words: ['tempest', 'barricade', 'sentinel', 'command'],
+      speed: 70,
+      pushback: 170,
+      damage: 2,
+      spriteScale: 1.18,
+    },
+  },
+  {
+    id: 3,
+    name: '深夜决战',
+    description: '黑暗之中强敌云集，谨慎守护城墙直至最后一刻。',
+    difficulty: 'hard',
+    wordPool: hard.words,
+    stageConfig: createStageConfig(
+      {
+        wall: { maxHp: 5 },
+        dangerZone: 160,
+        spawn: {
+          total: 26,
+          interval: 1200,
+          maxConcurrent: 5,
+          speed: { min: 100, max: 170 },
+          paths: ['straight', 'zigzag', 'drift'],
+        },
+        bombs: {
+          initial: 2,
+          max: 3,
+          cooldown: 15000,
+          comboThreshold: 4,
+        },
+      },
+      baseStage,
+    ),
+    dropRate: 0.38,
+    boss: {
+      name: '暮影指挥官',
+      words: ['resurgence', 'cataclysm', 'dominion', 'unbreakable', 'sovereign'],
+      speed: 82,
+      pushback: 200,
+      damage: 3,
+      spriteScale: 1.26,
+    },
+  },
+];
+
+export function getStageById(stageId: number): StageDefinition {
+  const stage = stages.find((entry) => entry.id === stageId);
+  if (!stage) {
+    throw new Error(`Stage ${stageId} not found`);
+  }
+  return stage;
+}

--- a/src/config/wordPools/hard.json
+++ b/src/config/wordPools/hard.json
@@ -1,0 +1,18 @@
+{
+  "language": "en",
+  "difficulty": "hard",
+  "words": [
+    "cataclysm",
+    "permafrost",
+    "luminescence",
+    "steadfast",
+    "retribution",
+    "oblivion",
+    "resurgence",
+    "battleground",
+    "nightwatch",
+    "overwhelm",
+    "aegis",
+    "sovereign"
+  ]
+}

--- a/src/config/wordPools/normal.json
+++ b/src/config/wordPools/normal.json
@@ -1,0 +1,18 @@
+{
+  "language": "en",
+  "difficulty": "normal",
+  "words": [
+    "arcane",
+    "guardian",
+    "fortress",
+    "bastion",
+    "phantom",
+    "arrowhead",
+    "brigade",
+    "vanguard",
+    "gauntlet",
+    "sentinel",
+    "harvest",
+    "tempest"
+  ]
+}

--- a/src/core/IconTextureLoader.ts
+++ b/src/core/IconTextureLoader.ts
@@ -35,13 +35,11 @@ const ICON_DEFINITIONS: IconDescriptor[] = [
     key: ICON_TEXTURE_KEYS.ranger,
     path: SvgBowman,
     fill: '#f8fafc',
-    backgroundFill: '#0f172a',
   },
   {
     key: ICON_TEXTURE_KEYS.enemy,
     path: SvgEvilMinion,
     fill: '#f87171',
-    backgroundFill: '#020617',
   },
   {
     key: ICON_TEXTURE_KEYS.castle,

--- a/src/core/StageManager.ts
+++ b/src/core/StageManager.ts
@@ -1,0 +1,48 @@
+import { StageDefinition, getStageById, stages } from '../config/stages';
+
+let currentStageIndex = 0;
+let unlockedStageIndex = 0;
+
+export function getStages(): readonly StageDefinition[] {
+  return stages;
+}
+
+export function getCurrentStageIndex(): number {
+  return currentStageIndex;
+}
+
+export function getCurrentStage(): StageDefinition {
+  return stages[currentStageIndex];
+}
+
+export function setCurrentStageIndex(index: number): void {
+  if (index < 0 || index >= stages.length) {
+    throw new Error(`Stage index ${index} out of range`);
+  }
+  currentStageIndex = index;
+}
+
+export function isStageUnlocked(index: number): boolean {
+  return index <= unlockedStageIndex;
+}
+
+export function markStageCompleted(index: number): void {
+  if (index < 0 || index >= stages.length) {
+    return;
+  }
+  unlockedStageIndex = Math.min(stages.length - 1, Math.max(unlockedStageIndex, index + 1));
+}
+
+export function getStageContext(stageId?: number): { stage: StageDefinition; index: number } {
+  if (typeof stageId === 'number') {
+    const stage = getStageById(stageId);
+    const index = stages.findIndex((entry) => entry.id === stageId);
+    return { stage, index: index === -1 ? 0 : index };
+  }
+  return { stage: getCurrentStage(), index: currentStageIndex };
+}
+
+export function resetProgress(): void {
+  currentStageIndex = 0;
+  unlockedStageIndex = 0;
+}

--- a/src/entities/Boss.ts
+++ b/src/entities/Boss.ts
@@ -1,0 +1,261 @@
+import Phaser from 'phaser';
+import { ICON_TEXTURE_KEYS } from '../core/IconTextureLoader';
+
+export type BossState = 'advancing' | 'retreating' | 'defeated' | 'breached';
+
+export interface BossOptions {
+  words: string[];
+  speed: number;
+  pushback: number;
+  damage: number;
+  breachX: number;
+  dangerZone: number;
+  spriteScale: number;
+}
+
+export class Boss extends Phaser.GameObjects.Container {
+  private readonly options: BossOptions;
+  private readonly sprite: Phaser.GameObjects.Image;
+  private readonly shadow: Phaser.GameObjects.Ellipse;
+  private readonly wordPanel: Phaser.GameObjects.Rectangle;
+  private readonly progressBar: Phaser.GameObjects.Rectangle;
+  private readonly typedText: Phaser.GameObjects.Text;
+  private readonly remainingText: Phaser.GameObjects.Text;
+
+  private readonly panelWidth: number;
+  private readonly panelHeight = 54;
+  private readonly textLeft: number;
+
+  private currentIndex = 0;
+  private currentInput = '';
+  private progress = 0;
+  private state: BossState = 'advancing';
+  private inDangerZone = false;
+  private currentWord: string;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, options: BossOptions) {
+    super(scene, x, y);
+    if (options.words.length === 0) {
+      throw new Error('Boss must have at least one word.');
+    }
+
+    this.options = options;
+    const longest = Math.max(...options.words.map((word) => word.length));
+    this.panelWidth = Math.max(200, longest * 30);
+    this.textLeft = 16 - this.panelWidth / 2 + 10;
+
+    this.currentWord = options.words[0];
+
+    this.sprite = scene.add
+      .image(0, -52, ICON_TEXTURE_KEYS.enemy)
+      .setDisplaySize(130 * options.spriteScale, 130 * options.spriteScale)
+      .setDepth(1);
+
+    this.shadow = scene.add
+      .ellipse(0, 68, this.panelWidth * 0.6, 36, 0x000000, 0.35)
+      .setDepth(-1);
+
+    this.wordPanel = scene.add
+      .rectangle(16, 28, this.panelWidth, this.panelHeight, 0x0b1220, 0.9)
+      .setStrokeStyle(3, 0x475569);
+
+    this.progressBar = scene.add
+      .rectangle(16 - this.panelWidth / 2, 28, 0, this.panelHeight, 0x38bdf8, 0.45)
+      .setOrigin(0, 0.5)
+      .setVisible(false);
+
+    const textStyle: Phaser.Types.GameObjects.Text.TextStyle = {
+      fontFamily: '"Noto Sans Mono", monospace',
+      fontSize: '26px',
+      color: '#f8fafc',
+    };
+
+    this.typedText = scene.add.text(this.textLeft, 28, '', textStyle).setOrigin(0, 0.5);
+    this.remainingText = scene.add
+      .text(this.textLeft, 28, this.currentWord, { ...textStyle, color: '#f8fafc' })
+      .setOrigin(0, 0.5);
+
+    this.add([this.shadow, this.sprite, this.wordPanel, this.progressBar, this.typedText, this.remainingText]);
+    scene.add.existing(this);
+  }
+
+  get word(): string {
+    return this.currentWord;
+  }
+
+  get damage(): number {
+    return this.options.damage;
+  }
+
+  isDefeated(): boolean {
+    return this.state === 'defeated';
+  }
+
+  advance(delta: number): void {
+    if (this.state !== 'advancing') {
+      return;
+    }
+
+    const deltaSeconds = delta / 1000;
+    this.x -= this.options.speed * deltaSeconds;
+
+    const totalDistance = Math.max(80, this.x - this.options.breachX);
+    const progressRatio = Phaser.Math.Clamp(1 - totalDistance / 600, 0.25, 0.9);
+    this.shadow.setScale(progressRatio, Phaser.Math.Clamp(progressRatio * 0.6, 0.28, 0.8));
+
+    if (this.x <= this.options.breachX) {
+      this.state = 'breached';
+      this.emit('breached');
+      this.fadeOut(280, '#ef4444');
+      return;
+    }
+
+    const distanceToBreach = this.x - this.options.breachX;
+    const nowDangerous = distanceToBreach <= this.options.dangerZone;
+    if (nowDangerous !== this.inDangerZone) {
+      this.inDangerZone = nowDangerous;
+      if (this.inDangerZone && this.state === 'advancing') {
+        this.wordPanel.setStrokeStyle(3, 0xf97316);
+      } else {
+        this.wordPanel.setStrokeStyle(3, 0x475569);
+      }
+    }
+  }
+
+  markAsTargeted(isTarget: boolean): void {
+    if (this.state === 'defeated') {
+      return;
+    }
+    if (isTarget) {
+      this.wordPanel.setStrokeStyle(3, 0x38bdf8);
+      this.sprite.setTint(0xfff7ed);
+    } else if (this.inDangerZone) {
+      this.wordPanel.setStrokeStyle(3, 0xf97316);
+      this.sprite.clearTint();
+    } else {
+      this.wordPanel.setStrokeStyle(3, 0x475569);
+      this.sprite.clearTint();
+    }
+  }
+
+  updateTypingPreview(input: string, isMistake: boolean): void {
+    this.currentInput = input;
+    this.typedText.setText(input);
+    this.remainingText.setText(this.currentWord.slice(input.length));
+    this.remainingText.setX(this.textLeft + this.typedText.displayWidth);
+
+    if (this.state === 'defeated') {
+      return;
+    }
+
+    if (isMistake) {
+      this.typedText.setColor('#f87171');
+    } else if (input.length >= this.currentWord.length) {
+      this.typedText.setColor('#34d399');
+    } else {
+      this.typedText.setColor('#38bdf8');
+    }
+  }
+
+  setProgress(progress: number): void {
+    this.progress = Phaser.Math.Clamp(progress, 0, this.currentWord.length);
+    const ratio = this.currentWord.length === 0 ? 0 : this.progress / this.currentWord.length;
+    const width = this.panelWidth * ratio;
+    this.progressBar.setDisplaySize(width, this.panelHeight);
+    this.progressBar.setVisible(ratio > 0);
+
+    if (this.progress >= this.currentWord.length) {
+      this.wordPanel.setFillStyle(0x14532d, 0.92);
+      this.sprite.setTint(0xfef3c7);
+      this.typedText.setColor('#34d399');
+    } else {
+      this.wordPanel.setFillStyle(0x0b1220, 0.9);
+      this.sprite.clearTint();
+    }
+  }
+
+  resetTypingState(): void {
+    this.progress = 0;
+    this.currentInput = '';
+    this.typedText.setColor('#38bdf8');
+    this.updateTypingPreview('', false);
+    this.progressBar.setVisible(false);
+    this.wordPanel.setFillStyle(0x0b1220, 0.9);
+  }
+
+  handleWordCompleted(): void {
+    if (this.state === 'defeated' || this.state === 'breached') {
+      return;
+    }
+
+    this.setProgress(this.currentWord.length);
+    this.updateTypingPreview(this.currentWord, false);
+
+    if (this.currentIndex >= this.options.words.length - 1) {
+      this.defeat();
+      return;
+    }
+
+    this.state = 'retreating';
+    this.scene.tweens.add({
+      targets: this,
+      x: this.x + this.options.pushback,
+      duration: 360,
+      ease: Phaser.Math.Easing.Cubic.Out,
+      onComplete: () => {
+        this.currentIndex += 1;
+        this.currentWord = this.options.words[this.currentIndex];
+        this.resetTypingState();
+        this.state = 'advancing';
+        this.emit('word:changed', this.currentWord);
+      },
+    });
+  }
+
+  stop(): void {
+    this.state = 'defeated';
+  }
+
+  private defeat(): void {
+    if (this.state === 'defeated') {
+      return;
+    }
+    this.state = 'defeated';
+    this.scene.tweens.add({
+      targets: this,
+      alpha: 0,
+      scale: 0.6,
+      duration: 320,
+      ease: Phaser.Math.Easing.Cubic.In,
+      onComplete: () => {
+        this.emit('defeated');
+        this.destroy();
+      },
+    });
+  }
+
+  private fadeOut(offset: number, color: string): void {
+    this.wordPanel.setStrokeStyle(3, Phaser.Display.Color.HexStringToColor(color).color);
+    this.scene.tweens.add({
+      targets: this,
+      alpha: 0,
+      x: this.x - offset,
+      duration: 320,
+      ease: Phaser.Math.Easing.Cubic.In,
+      onComplete: () => {
+        this.emit('breach:completed');
+        this.destroy();
+      },
+    });
+  }
+
+  override destroy(fromScene?: boolean): void {
+    this.sprite.destroy();
+    this.shadow.destroy();
+    this.wordPanel.destroy();
+    this.progressBar.destroy();
+    this.typedText.destroy();
+    this.remainingText.destroy();
+    super.destroy(fromScene);
+  }
+}

--- a/src/entities/PlayerStats.ts
+++ b/src/entities/PlayerStats.ts
@@ -16,6 +16,11 @@ export class PlayerStats {
     return this.wallHealth;
   }
 
+  repair(amount = 1): number {
+    this.wallHealth = Math.min(this.maxWallHealth, this.wallHealth + amount);
+    return this.wallHealth;
+  }
+
   isDefeated(): boolean {
     return this.wallHealth <= 0;
   }

--- a/src/entities/Powerup.ts
+++ b/src/entities/Powerup.ts
@@ -1,0 +1,97 @@
+import Phaser from 'phaser';
+import { ICON_TEXTURE_KEYS } from '../core/IconTextureLoader';
+
+export type PowerupType = 'bomb' | 'repair';
+
+interface PowerupOptions {
+  type: PowerupType;
+  fallSpeed: number;
+  groundY: number;
+}
+
+export class Powerup extends Phaser.GameObjects.Container {
+  readonly type: PowerupType;
+  private readonly speed: number;
+  private readonly groundY: number;
+  private collected = false;
+  private readonly badge: Phaser.GameObjects.Rectangle;
+  private readonly icon: Phaser.GameObjects.Image;
+  private readonly label: Phaser.GameObjects.Text;
+
+  constructor(scene: Phaser.Scene, x: number, options: PowerupOptions) {
+    super(scene, x, -60);
+
+    this.type = options.type;
+    this.speed = options.fallSpeed;
+    this.groundY = options.groundY;
+
+    const tint = this.type === 'bomb' ? 0xf97316 : 0x38bdf8;
+    this.badge = scene.add
+      .rectangle(0, 0, 52, 52, 0x0f172a, 0.8)
+      .setStrokeStyle(2, tint)
+      .setRadius(12);
+
+    const texture = this.type === 'bomb' ? ICON_TEXTURE_KEYS.bomb : ICON_TEXTURE_KEYS.wallEmblem;
+    this.icon = scene.add.image(0, 0, texture).setDisplaySize(32, 32).setTint(tint);
+
+    const labelText = this.type === 'bomb' ? '补给' : '维修';
+    this.label = scene.add
+      .text(0, 42, labelText, {
+        fontFamily: '"Noto Sans SC", sans-serif',
+        fontSize: '18px',
+        color: '#e2e8f0',
+      })
+      .setOrigin(0.5, 0);
+
+    this.add([this.badge, this.icon, this.label]);
+    this.setDepth(9);
+    scene.add.existing(this);
+
+    scene.tweens.add({
+      targets: this.icon,
+      angle: { from: -6, to: 6 },
+      duration: 600,
+      repeat: -1,
+      yoyo: true,
+      ease: Phaser.Math.Easing.Sine.InOut,
+    });
+  }
+
+  update(delta: number): void {
+    if (this.collected) {
+      return;
+    }
+
+    const deltaSeconds = delta / 1000;
+    this.y += this.speed * deltaSeconds;
+
+    if (this.y >= this.groundY) {
+      this.collect();
+    }
+  }
+
+  collect(): void {
+    if (this.collected) {
+      return;
+    }
+    this.collected = true;
+    this.scene.tweens.add({
+      targets: this,
+      alpha: 0,
+      scale: 1.2,
+      duration: 240,
+      ease: Phaser.Math.Easing.Cubic.Out,
+      onComplete: () => {
+        this.emit('collected', this.type);
+        this.destroy();
+      },
+    });
+  }
+
+  override destroy(fromScene?: boolean): void {
+    this.badge.destroy();
+    this.icon.destroy();
+    this.label.destroy();
+    super.destroy(fromScene);
+  }
+}

--- a/src/systems/BombSystem.ts
+++ b/src/systems/BombSystem.ts
@@ -41,6 +41,14 @@ export class BombSystem {
     return this.charges > 0;
   }
 
+  getCharges(): number {
+    return this.charges;
+  }
+
+  getMaxCharges(): number {
+    return this.maxCharges;
+  }
+
   activate(): boolean {
     if (!this.canActivate()) {
       return false;
@@ -51,6 +59,23 @@ export class BombSystem {
     this.publishStatus();
     EventBus.emit(Events.BombActivated);
     return true;
+  }
+
+  addCharge(amount = 1): boolean {
+    if (amount <= 0) {
+      return false;
+    }
+
+    const previous = this.charges;
+    this.charges = Math.min(this.maxCharges, this.charges + amount);
+    if (this.charges !== previous) {
+      this.cooldownRemaining = 0;
+      this.publishStatus();
+      return true;
+    }
+
+    this.publishStatus();
+    return false;
   }
 
   registerCombo(combo: number): void {


### PR DESCRIPTION
## Summary
- add configurable stage progression with boss encounters and item drop tuning
- redesign gameplay scene to highlight typing on enemies, spawn bosses, and handle bomb/repair powerups
- refresh menu and result scenes with stage selection, navigation, and updated assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d2c83201c88330b9cd29270e70a51d