### PR TITLE
Refine UI stats layout and require typing for bomb supplies

### DIFF
--- a/src/core/UIScene.ts
+++ b/src/core/UIScene.ts
@@ -13,6 +13,7 @@ export class UIScene extends Phaser.Scene {
   private messageTimer?: Phaser.Time.TimerEvent;
   private bombIcon!: Phaser.GameObjects.Image;
   private wallIcon!: Phaser.GameObjects.Image;
+  private textLayouts = new Map<Phaser.GameObjects.Text, () => void>();
 
   constructor() {
     super('UIScene');
@@ -37,76 +38,99 @@ export class UIScene extends Phaser.Scene {
   }
 
   private setupTexts(): void {
+    this.textLayouts.clear();
+
     const style: Phaser.Types.GameObjects.Text.TextStyle = {
       fontFamily: '"Noto Sans SC", sans-serif',
-      fontSize: '20px',
+      fontSize: '16px',
       color: '#f8fafc',
     };
 
-    const panel = this.add
-      .rectangle(16, 16, 368, 184, 0x020617, 0.7)
-      .setOrigin(0, 0)
-      .setStrokeStyle(2, 0x1e293b);
+    const spacing = 6;
+    const { width, height } = this.scale;
 
-    const baseX = panel.x + 64;
-    let lineY = panel.y + 32;
-    const lineGap = 28;
+    const createBadge = (
+      x: number,
+      y: number,
+      texture: string,
+      tint: number,
+      initialText: string,
+      alignment: 'left' | 'center' | 'right',
+    ): { text: Phaser.GameObjects.Text; icon: Phaser.GameObjects.Image } => {
+      const container = this.add.container(x, y);
+      container.setDepth(30);
+      const icon = this.add
+        .image(0, 0, texture)
+        .setDisplaySize(20, 20)
+        .setTint(tint);
+      const label = this.add.text(0, 0, initialText, style);
+      container.add([icon, label]);
 
-    const makeIcon = (texture: string, tint: number) =>
-      this.add
-        .image(panel.x + 32, lineY, texture)
-        .setDisplaySize(28, 28)
-        .setTint(tint)
-        .setOrigin(0.5);
+      const applyLayout = () => {
+        const iconWidth = icon.displayWidth;
+        const textWidth = label.displayWidth;
+        switch (alignment) {
+          case 'left':
+            icon.setOrigin(0, 0.5);
+            icon.setPosition(0, 0);
+            label.setOrigin(0, 0.5);
+            label.setPosition(iconWidth + spacing, 0);
+            break;
+          case 'right':
+            icon.setOrigin(1, 0.5);
+            icon.setPosition(0, 0);
+            label.setOrigin(1, 0.5);
+            label.setPosition(-iconWidth - spacing, 0);
+            break;
+          default: {
+            const totalWidth = iconWidth + spacing + textWidth;
+            icon.setOrigin(0.5, 0.5);
+            label.setOrigin(0.5, 0.5);
+            icon.setPosition(-totalWidth / 2 + iconWidth / 2, 0);
+            label.setPosition(icon.x + iconWidth / 2 + spacing + textWidth / 2, 0);
+            break;
+          }
+        }
+      };
 
-    makeIcon(ICON_TEXTURE_KEYS.target, 0x38bdf8);
-    this.scoreText = this.add.text(baseX, lineY, 'Score: 0', style).setOrigin(0, 0.5);
-    lineY += lineGap;
+      this.textLayouts.set(label, applyLayout);
+      applyLayout();
+      return { text: label, icon };
+    };
 
-    makeIcon(ICON_TEXTURE_KEYS.arrow, 0xfacc15);
-    this.comboText = this.add.text(baseX, lineY, 'Combo: 0', style).setOrigin(0, 0.5);
-    lineY += lineGap;
+    this.scoreText = createBadge(18, 26, ICON_TEXTURE_KEYS.target, 0x38bdf8, 'Score: 0', 'left').text;
+    this.comboText = createBadge(width - 18, 26, ICON_TEXTURE_KEYS.arrow, 0xfacc15, 'Combo: 0', 'right').text;
+    this.enemyText = createBadge(width / 2, 26, ICON_TEXTURE_KEYS.enemy, 0xf87171, 'Enemies: 0', 'center').text;
 
-    makeIcon(ICON_TEXTURE_KEYS.ranger, 0xf8fafc);
-    this.accuracyText = this.add.text(baseX, lineY, 'Accuracy: 100%', style).setOrigin(0, 0.5);
-    lineY += lineGap;
+    this.accuracyText = createBadge(18, height - 132, ICON_TEXTURE_KEYS.ranger, 0xf8fafc, 'Accuracy: 100%', 'left').text;
 
-    this.add
-      .image(panel.x + 32, lineY, ICON_TEXTURE_KEYS.enemy)
-      .setDisplaySize(28, 28)
-      .setTint(0xf87171)
-      .setOrigin(0.5);
-    this.enemyText = this.add
-      .text(baseX, lineY, 'Enemies: 0', style)
-      .setOrigin(0, 0.5);
-    lineY += lineGap;
+    const bombBadge = createBadge(18, height - 92, ICON_TEXTURE_KEYS.bomb, 0xf97316, 'Bombs: 0', 'left');
+    this.bombIcon = bombBadge.icon;
+    this.bombText = bombBadge.text;
 
-    this.bombIcon = this.add
-      .image(panel.x + 32, lineY, ICON_TEXTURE_KEYS.bomb)
-      .setDisplaySize(28, 28)
-      .setTint(0xf97316)
-      .setOrigin(0.5);
-    this.bombText = this.add
-      .text(baseX, lineY, 'Bombs: 0', style)
-      .setOrigin(0, 0.5);
-    lineY += lineGap;
-
-    this.wallIcon = this.add
-      .image(panel.x + 32, lineY, ICON_TEXTURE_KEYS.wallEmblem)
-      .setDisplaySize(28, 28)
-      .setTint(0xcbd5f5)
-      .setOrigin(0.5);
-    this.wallText = this.add
-      .text(baseX, lineY, 'Wall Integrity: 0/0', style)
-      .setOrigin(0, 0.5);
+    const wallBadge = createBadge(
+      width - 18,
+      height - 92,
+      ICON_TEXTURE_KEYS.wallEmblem,
+      0xcbd5f5,
+      'Wall Integrity: 0/0',
+      'right',
+    );
+    this.wallIcon = wallBadge.icon;
+    this.wallText = wallBadge.text;
 
     this.messageText = this.add
       .text(this.scale.width / 2, this.scale.height - 44, '', {
         ...style,
-        fontSize: '18px',
+        fontSize: '16px',
         color: '#e2e8f0',
       })
       .setOrigin(0.5);
+  }
+
+  private refreshBadgeLayout(text: Phaser.GameObjects.Text): void {
+    const layout = this.textLayouts.get(text);
+    layout?.();
   }
 
   private handleScoreUpdated(summary: ScoreSummary): void {
@@ -119,6 +143,10 @@ export class UIScene extends Phaser.Scene {
     this.enemyText.setText(
       `Enemies: ${summary.enemiesDefeated} (Typed ${summary.typedEliminations} / Bomb ${summary.bombEliminations})`,
     );
+    this.refreshBadgeLayout(this.scoreText);
+    this.refreshBadgeLayout(this.comboText);
+    this.refreshBadgeLayout(this.accuracyText);
+    this.refreshBadgeLayout(this.enemyText);
   }
 
   private showMessage(message: string): void {
@@ -138,6 +166,7 @@ export class UIScene extends Phaser.Scene {
       this.bombText.setText(`Bombs: ${status.charges}/${status.maxCharges}`);
       this.bombIcon.setTint(status.charges > 0 ? 0xf97316 : 0x64748b);
     }
+    this.refreshBadgeLayout(this.bombText);
   }
 
   private updateWallStatus(status: WallStatus): void {
@@ -153,6 +182,7 @@ export class UIScene extends Phaser.Scene {
       this.wallText.setColor('#f8fafc');
       this.wallIcon.setTint(0xcbd5f5);
     }
+    this.refreshBadgeLayout(this.wallText);
   }
 
   private handleBombActivated(): void {

--- a/src/entities/Powerup.ts
+++ b/src/entities/Powerup.ts
@@ -3,20 +3,37 @@ import { ICON_TEXTURE_KEYS } from '../core/IconTextureLoader';
 
 export type PowerupType = 'bomb' | 'repair';
 
+export type PowerupCollectTrigger = 'typed' | 'auto';
+
 interface PowerupOptions {
   type: PowerupType;
   fallSpeed: number;
   groundY: number;
+  requiresTyping?: boolean;
+  word?: string;
 }
 
 export class Powerup extends Phaser.GameObjects.Container {
   readonly type: PowerupType;
+  readonly requiresTyping: boolean;
+
   private readonly speed: number;
   private readonly groundY: number;
+  private readonly baseTint: number;
+  private readonly targetWord?: string;
+
   private collected = false;
+  private targeted = false;
+
   private readonly badge: Phaser.GameObjects.Rectangle;
   private readonly icon: Phaser.GameObjects.Image;
-  private readonly label: Phaser.GameObjects.Text;
+  private readonly label?: Phaser.GameObjects.Text;
+  private readonly wordPanel?: Phaser.GameObjects.Rectangle;
+  private readonly progressBar?: Phaser.GameObjects.Rectangle;
+  private readonly typedText?: Phaser.GameObjects.Text;
+  private readonly remainingText?: Phaser.GameObjects.Text;
+
+  private progress = 0;
 
   constructor(scene: Phaser.Scene, x: number, options: PowerupOptions) {
     super(scene, x, -60);
@@ -24,26 +41,61 @@ export class Powerup extends Phaser.GameObjects.Container {
     this.type = options.type;
     this.speed = options.fallSpeed;
     this.groundY = options.groundY;
+    this.requiresTyping = Boolean(options.requiresTyping);
+    this.targetWord = options.word;
 
-    const tint = this.type === 'bomb' ? 0xf97316 : 0x38bdf8;
+    if (this.requiresTyping && !this.targetWord) {
+      throw new Error('Typed powerups must provide a word.');
+    }
+
+    this.baseTint = this.type === 'bomb' ? 0xf97316 : 0x38bdf8;
+
     this.badge = scene.add
       .rectangle(0, 0, 52, 52, 0x0f172a, 0.8)
-      .setStrokeStyle(2, tint)
+      .setStrokeStyle(2, this.baseTint)
       .setRadius(12);
 
     const texture = this.type === 'bomb' ? ICON_TEXTURE_KEYS.bomb : ICON_TEXTURE_KEYS.wallEmblem;
-    this.icon = scene.add.image(0, 0, texture).setDisplaySize(32, 32).setTint(tint);
+    this.icon = scene.add.image(0, 0, texture).setDisplaySize(32, 32).setTint(this.baseTint);
 
-    const labelText = this.type === 'bomb' ? '补给' : '维修';
-    this.label = scene.add
-      .text(0, 42, labelText, {
-        fontFamily: '"Noto Sans SC", sans-serif',
-        fontSize: '18px',
+    if (this.requiresTyping && this.targetWord) {
+      const panelWidth = Math.max(96, this.targetWord.length * 22);
+      const panelHeight = 34;
+
+      this.progressBar = scene.add
+        .rectangle(-panelWidth / 2, 44, 0, panelHeight, this.baseTint, 0.3)
+        .setOrigin(0, 0.5)
+        .setVisible(false);
+
+      this.wordPanel = scene.add
+        .rectangle(0, 44, panelWidth, panelHeight, 0x0f172a, 0.86)
+        .setStrokeStyle(2, 0x475569);
+
+      const textStyle: Phaser.Types.GameObjects.Text.TextStyle = {
+        fontFamily: '"Noto Sans Mono", monospace',
+        fontSize: '20px',
         color: '#e2e8f0',
-      })
-      .setOrigin(0.5, 0);
+      };
 
-    this.add([this.badge, this.icon, this.label]);
+      this.typedText = scene.add
+        .text(-panelWidth / 2 + 12, 44, '', { ...textStyle, color: '#38bdf8' })
+        .setOrigin(0, 0.5);
+      this.remainingText = scene.add.text(this.typedText.x, 44, this.targetWord, textStyle).setOrigin(0, 0.5);
+
+      this.add([this.badge, this.icon, this.progressBar, this.wordPanel, this.typedText, this.remainingText]);
+      this.resetTypingState();
+    } else {
+      const labelText = this.type === 'bomb' ? '补给' : '维修';
+      this.label = scene.add
+        .text(0, 42, labelText, {
+          fontFamily: '"Noto Sans SC", sans-serif',
+          fontSize: '18px',
+          color: '#e2e8f0',
+        })
+        .setOrigin(0.5, 0);
+      this.add([this.badge, this.icon, this.label]);
+    }
+
     this.setDepth(9);
     scene.add.existing(this);
 
@@ -57,6 +109,14 @@ export class Powerup extends Phaser.GameObjects.Container {
     });
   }
 
+  get word(): string {
+    return this.targetWord ?? '';
+  }
+
+  isTypingActive(): boolean {
+    return this.requiresTyping && !this.collected;
+  }
+
   update(delta: number): void {
     if (this.collected) {
       return;
@@ -66,23 +126,145 @@ export class Powerup extends Phaser.GameObjects.Container {
     this.y += this.speed * deltaSeconds;
 
     if (this.y >= this.groundY) {
-      this.collect();
+      if (this.requiresTyping) {
+        this.handleMissed();
+      } else {
+        this.collect('auto');
+      }
     }
   }
 
-  collect(): void {
+  setProgress(progressCount: number): void {
+    if (!this.requiresTyping || !this.targetWord) {
+      return;
+    }
+
+    this.progress = Phaser.Math.Clamp(progressCount, 0, this.targetWord.length);
+    const ratio = this.targetWord.length === 0 ? 0 : this.progress / this.targetWord.length;
+    const width = (this.wordPanel?.width ?? 0) * ratio;
+
+    if (this.progressBar) {
+      this.progressBar.setDisplaySize(width, this.progressBar.height);
+      this.progressBar.setVisible(ratio > 0);
+    }
+
+    if (this.wordPanel) {
+      if (this.progress >= this.targetWord.length) {
+        this.wordPanel.setFillStyle(0x14532d, 0.9);
+        this.icon.setTint(0xfef3c7);
+      } else {
+        this.wordPanel.setFillStyle(0x0f172a, 0.86);
+        if (!this.targeted) {
+          this.icon.setTint(this.baseTint);
+        }
+      }
+    }
+  }
+
+  markAsTargeted(isTarget: boolean): void {
+    this.targeted = isTarget;
+    if (this.requiresTyping) {
+      if (isTarget) {
+        this.wordPanel?.setStrokeStyle(3, 0x38bdf8);
+        this.icon.setTint(0xfff7ed);
+      } else {
+        this.wordPanel?.setStrokeStyle(2, 0x475569);
+        this.icon.setTint(this.baseTint);
+      }
+      return;
+    }
+
+    const strokeTint = this.type === 'bomb' ? 0xf97316 : 0x38bdf8;
+    this.badge.setStrokeStyle(isTarget ? 3 : 2, strokeTint);
+    this.icon.setTint(isTarget ? 0xfff7ed : this.baseTint);
+  }
+
+  updateTypingPreview(input: string, isMistake: boolean): void {
+    if (!this.requiresTyping || !this.targetWord || !this.typedText || !this.remainingText) {
+      return;
+    }
+
+    const trimmed = input.slice(0, this.targetWord.length);
+    this.typedText.setText(trimmed);
+    this.remainingText.setText(this.targetWord.slice(trimmed.length));
+    this.remainingText.setX(this.typedText.x + this.typedText.displayWidth);
+
+    if (isMistake) {
+      this.typedText.setColor('#f87171');
+    } else if (trimmed.length >= this.targetWord.length) {
+      this.typedText.setColor('#34d399');
+    } else {
+      this.typedText.setColor('#38bdf8');
+    }
+  }
+
+  resetTypingState(): void {
+    if (!this.requiresTyping) {
+      return;
+    }
+
+    this.progress = 0;
+    if (this.progressBar) {
+      this.progressBar.setDisplaySize(0, this.progressBar.height);
+      this.progressBar.setVisible(false);
+    }
+    this.wordPanel?.setFillStyle(0x0f172a, 0.86);
+    this.icon.setTint(this.baseTint);
+    this.updateTypingPreview('', false);
+  }
+
+  completeByTyping(): void {
+    if (this.requiresTyping && this.targetWord) {
+      this.setProgress(this.targetWord.length);
+      this.updateTypingPreview(this.targetWord, false);
+      this.collect('typed');
+    } else {
+      this.collect('auto');
+    }
+  }
+
+  collect(trigger: PowerupCollectTrigger = 'auto'): void {
     if (this.collected) {
       return;
     }
+
+    if (this.requiresTyping && trigger !== 'typed') {
+      return;
+    }
+
     this.collected = true;
+    this.targeted = false;
+    this.wordPanel?.setStrokeStyle(2, 0x475569);
+    this.icon.setTint(this.baseTint);
+
     this.scene.tweens.add({
       targets: this,
       alpha: 0,
-      scale: 1.2,
+      scale: 1.1,
       duration: 240,
       ease: Phaser.Math.Easing.Cubic.Out,
       onComplete: () => {
-        this.emit('collected', this.type);
+        this.emit('collected', { type: this.type, trigger });
+        this.destroy();
+      },
+    });
+  }
+
+  private handleMissed(): void {
+    if (this.collected) {
+      return;
+    }
+
+    this.collected = true;
+    this.targeted = false;
+    this.scene.tweens.add({
+      targets: this,
+      alpha: 0,
+      scale: 0.8,
+      duration: 220,
+      ease: Phaser.Math.Easing.Cubic.In,
+      onComplete: () => {
+        this.emit('missed', this.type);
         this.destroy();
       },
     });
@@ -91,7 +273,11 @@ export class Powerup extends Phaser.GameObjects.Container {
   override destroy(fromScene?: boolean): void {
     this.badge.destroy();
     this.icon.destroy();
-    this.label.destroy();
+    this.label?.destroy();
+    this.wordPanel?.destroy();
+    this.progressBar?.destroy();
+    this.typedText?.destroy();
+    this.remainingText?.destroy();
     super.destroy(fromScene);
   }
 }


### PR DESCRIPTION
## Summary
- redesign the HUD to place score, combo, accuracy, enemy, bomb, and wall readouts in smaller badges around the screen
- add typed power-up support that assigns words to bomb supplies and requires successful input before awarding charges
- handle missed bomb crates and prevent combo penalties for supply typos while keeping repair power-ups unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d40d8e9c3c8330919645ad04aa7a52