### PR TITLE
Fix Powerup type override

### DIFF
--- a/src/entities/Powerup.ts
+++ b/src/entities/Powerup.ts
@@ -14,7 +14,7 @@ interface PowerupOptions {
 }
 
 export class Powerup extends Phaser.GameObjects.Container {
-  readonly type: PowerupType;
+  override readonly type: PowerupType;
   readonly requiresTyping: boolean;
 
   private readonly speed: number;


### PR DESCRIPTION
## Summary
- mark the Powerup container's type field as an override to align with Phaser's base class definition

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d489cbcbf08330be35b7df718b201f